### PR TITLE
Adapt to GHC 9.2.3 and recent package versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist*
 result*
 *.sw*
 *.ghc*
+cabal.project.local

--- a/eigen.cabal
+++ b/eigen.cabal
@@ -59,7 +59,7 @@ copyright:      (c) 2013-2015, Oleg Sidorkin,
 author:         Oleg Sidorkin <oleg.sidorkin@gmail.com>
 maintainer:     chessai <chessai1996@gmail.com>
 build-type:     Simple
-tested-with:    GHC == 8.2.2, GHC == 8.4.3, GHC == 8.6.1
+tested-with:    GHC == 8.2.2, GHC == 8.4.3, GHC == 8.6.1, GHC == 9.2.3
 extra-source-files: cbits/eigen-runtime.h
     cbits/eigen-dense.h
     cbits/eigen-la.h
@@ -1707,13 +1707,13 @@ library
       -Wall
     build-depends:
         base >= 4.10 && < 5
-      , binary >= 0.8.0.0 && < 0.8.6.0
-      , bytestring >= 0.10.4.0 && < 0.11.0.0
-      , constraints >= 0.10.0 && < 0.11.0
+      , binary >= 0.8.0.0 && < 0.11
+      , bytestring >= 0.10.4.0 && < 0.12.0.0
+      , constraints >= 0.10.0 && < 0.14
       , ghc-prim
-      , primitive >= 0.6.4.0 && < 0.7
+      , primitive >= 0.6.4.0 && < 0.8
       , transformers >= 0.3 && < 0.6
-      , vector >= 0.5 && < 0.13
+      , vector >= 0.5 && < 0.14
     default-language:
       Haskell2010
     include-dirs:

--- a/eigen.cabal.template
+++ b/eigen.cabal.template
@@ -59,7 +59,7 @@ copyright:      (c) 2013-2015, Oleg Sidorkin,
 author:         Oleg Sidorkin <oleg.sidorkin@gmail.com>
 maintainer:     chessai <chessai1996@gmail.com>
 build-type:     Simple
-tested-with:    GHC == 8.2.2, GHC == 8.4.3, GHC == 8.6.1
+tested-with:    GHC == 8.2.2, GHC == 8.4.3, GHC == 8.6.1, GHC == 9.2.3
 extra-source-files: cbits/eigen-runtime.h
     cbits/eigen-dense.h
     cbits/eigen-la.h
@@ -89,13 +89,13 @@ library
       -Wall
     build-depends:
         base >= 4.10 && < 5
-      , binary >= 0.8.0.0 && < 0.8.6.0
-      , bytestring >= 0.10.4.0 && < 0.11.0.0
-      , constraints >= 0.10.0 && < 0.11.0
+      , binary >= 0.8.0.0 && < 0.11
+      , bytestring >= 0.10.4.0 && < 0.12.0.0
+      , constraints >= 0.10.0 && < 0.14
       , ghc-prim
-      , primitive >= 0.6.4.0 && < 0.7
+      , primitive >= 0.6.4.0 && < 0.8
       , transformers >= 0.3 && < 0.6
-      , vector >= 0.5 && < 0.13
+      , vector >= 0.5 && < 0.14
     default-language:
       Haskell2010
     include-dirs:

--- a/src/Eigen/Solver/LA.hs
+++ b/src/Eigen/Solver/LA.hs
@@ -19,7 +19,7 @@ module Eigen.Solver.LA
   , linearRegression
   ) where
 
-import Eigen.Internal (Elem, Cast(..))
+import Eigen.Internal (Cast(..))
 import Eigen.Matrix
 import Foreign.C.Types (CInt)
 import Foreign.Marshal.Alloc (alloca)

--- a/src/Eigen/SparseMatrix.hs
+++ b/src/Eigen/SparseMatrix.hs
@@ -491,11 +491,11 @@ unsafeThaw :: (Elem a, PrimMonad p) => SparseMatrix n m a -> p (SMM.MSparseMatri
 unsafeThaw (SparseMatrix fp) = return $! SMM.MSparseMatrix fp
 
 -- | Return a single row of the sparse matrix.
-getRow :: forall n m r a. (Elem a, KnownNat n, KnownNat m, KnownNat r, r <= n, 1 <= n) => Row r -> SparseMatrix n m a -> SparseMatrix 1 m a
+getRow :: forall n m r a. (Elem a, KnownNat n, KnownNat m, KnownNat r, r <= n, 1 <= n, 0 <= m) => Row r -> SparseMatrix n m a -> SparseMatrix 1 m a
 getRow row mat = block row (Col @0) (Row @1) (Col @m) mat
 
 -- | Return a single column of the sparse matrix.
-getCol :: forall n m c a. (Elem a, KnownNat n, KnownNat m, KnownNat c, c <= m, 1 <= m) => Col c -> SparseMatrix n m a -> SparseMatrix n 1 a
+getCol :: forall n m c a. (Elem a, KnownNat n, KnownNat m, KnownNat c, c <= m, 1 <= m, 0 <= n) => Col c -> SparseMatrix n m a -> SparseMatrix n 1 a
 getCol col mat = block (Row @0) col (Row @n) (Col @1) mat
 
 -- | Return all rows of the sparse matrix.


### PR DESCRIPTION
These changes make the package usable with the latest GHC 9.2.3.

There are minor changes to the source code of SparseMatrix where additional constraints 0 <= n resp. 0 <= m are needed. Apart from I just upgraded the package constraints tries the test suites.