### PR TITLE
Use system-cxx-std-lib on GHC >= 9.4

### DIFF
--- a/eigen.cabal
+++ b/eigen.cabal
@@ -1725,8 +1725,12 @@ library
       cbits/eigen-sparse.cpp
       cbits/eigen-la.cpp
       cbits/eigen-sparse-la.cpp
-    extra-libraries:
-      stdc++
+    if impl(ghc >= 9.4)
+      build-depends:
+        system-cxx-std-lib
+    else
+      extra-libraries:
+        stdc++
 
 Test-Suite test-solve
   type:               exitcode-stdio-1.0


### PR DESCRIPTION
This improves `C++` support on GHC >= 9.4, in particular on Windows where without this patch I get errors of the form

```
stdc++ or dependencies not loaded
```