### PR TITLE
Expose unsafeCoeff

### DIFF
--- a/src/Eigen/Matrix.hs
+++ b/src/Eigen/Matrix.hs
@@ -55,6 +55,7 @@ module Eigen.Matrix
 
   , (!)
   , coeff
+  , unsafeCoeff
   , generate
   , sum
   , prod


### PR DESCRIPTION
This commit exposes `unsafeCoeff` from the `Eigen.Matrix` module. This just makes it easier to construct a matrix when one has value-level indices in hand, avoiding a rigamarole of `someNatVal` etc.