### PR TITLE
GHC 9.14 compatibility

### DIFF
--- a/eigen.cabal
+++ b/eigen.cabal
@@ -1708,11 +1708,11 @@ library
     build-depends:
         base >= 4.10 && < 5
       , binary >= 0.8.0.0 && < 0.11
-      , bytestring >= 0.10.4.0 && < 0.12.0.0
-      , constraints >= 0.10.0 && < 0.14
+      , bytestring >= 0.10.4.0 && < 0.13.0.0
+      , constraints >= 0.10.0 && < 0.15
       , ghc-prim
-      , primitive >= 0.6.4.0 && < 0.8
-      , transformers >= 0.3 && < 0.6
+      , primitive >= 0.6.4.0 && < 0.10
+      , transformers >= 0.3 && < 0.7
       , vector >= 0.5 && < 0.14
     default-language:
       Haskell2010

--- a/src/Eigen/Internal.hsc
+++ b/src/Eigen/Internal.hsc
@@ -6,7 +6,7 @@
 
 {-# LANGUAGE AllowAmbiguousTypes       #-}
 {-# LANGUAGE BangPatterns              #-}
-{-# LANGUAGE CPP                       #-} 
+{-# LANGUAGE CPP                       #-}
 {-# LANGUAGE EmptyDataDecls            #-}
 {-# LANGUAGE FlexibleContexts          #-}
 {-# LANGUAGE FlexibleInstances         #-}
@@ -15,6 +15,7 @@
 {-# LANGUAGE GADTs                     #-}
 {-# LANGUAGE KindSignatures            #-}
 {-# LANGUAGE LambdaCase                #-}
+{-# LANGUAGE PolyKinds                 #-}
 {-# LANGUAGE MagicHash                 #-}
 {-# LANGUAGE MultiParamTypeClasses     #-}
 {-# LANGUAGE Rank2Types                #-}
@@ -22,7 +23,6 @@
 {-# LANGUAGE StandaloneDeriving        #-}
 {-# LANGUAGE TypeApplications          #-}
 {-# LANGUAGE TypeFamilyDependencies    #-}
-{-# LANGUAGE TypeInType                #-}
 {-# LANGUAGE UnboxedTuples             #-}
 {-# LANGUAGE UndecidableInstances      #-}
 

--- a/src/Eigen/Internal.hsc
+++ b/src/Eigen/Internal.hsc
@@ -7,6 +7,7 @@
 {-# LANGUAGE AllowAmbiguousTypes       #-}
 {-# LANGUAGE BangPatterns              #-}
 {-# LANGUAGE CPP                       #-}
+{-# LANGUAGE DataKinds                 #-}
 {-# LANGUAGE EmptyDataDecls            #-}
 {-# LANGUAGE FlexibleContexts          #-}
 {-# LANGUAGE FlexibleInstances         #-}

--- a/src/Eigen/Matrix.hs
+++ b/src/Eigen/Matrix.hs
@@ -55,6 +55,7 @@ module Eigen.Matrix
 
   , (!)
   , coeff
+  , unsafeCoeff
   , generate
   , sum
   , prod

--- a/src/Eigen/Matrix.hs
+++ b/src/Eigen/Matrix.hs
@@ -96,7 +96,11 @@ module Eigen.Matrix
 import Control.Monad (when)
 import Control.Monad.ST (ST)
 import Prelude hiding
-  (map, null, filter, length, foldl, any, all, sum)
+  ( map, null, filter, length, foldl, any, all, sum
+#if MIN_VERSION_base(4,20,0)
+  , foldl'
+#endif
+  )
 import Control.Monad (forM_)
 import Control.Monad.Primitive (PrimMonad(..))
 import Data.Binary (Binary(..))

--- a/src/Eigen/Matrix/Mutable.hs
+++ b/src/Eigen/Matrix/Mutable.hs
@@ -3,10 +3,10 @@
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE PolyKinds           #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE TypeInType          #-}
 {-# LANGUAGE TypeOperators       #-}
 
 #if __GLASGOW_HASKELL__ >= 805
@@ -46,7 +46,7 @@ module Eigen.Matrix.Mutable
 
 import Eigen.Internal
   ( Elem
-  , C(..)
+  , C(..), toC, fromC
   , natToInt
   , Row(..)
   , Col(..)

--- a/src/Eigen/SparseMatrix.hs
+++ b/src/Eigen/SparseMatrix.hs
@@ -2,10 +2,10 @@
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE PolyKinds           #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE TypeInType          #-}
 {-# LANGUAGE TypeOperators       #-}
 
 module Eigen.SparseMatrix

--- a/src/Eigen/SparseMatrix/Mutable.hs
+++ b/src/Eigen/SparseMatrix/Mutable.hs
@@ -2,10 +2,10 @@
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE PolyKinds           #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE TypeInType          #-}
 {-# LANGUAGE TypeOperators       #-}
 
 module Eigen.SparseMatrix.Mutable


### PR DESCRIPTION
This adds compatibility for GHC 9.14 by adding `DataKinds` to `Eigen/Internal.hsc`.